### PR TITLE
0.7.0

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,0 @@
-This project is no longer active.
-
-Thank you for the many years we have worked together on this project.
-
-Feel free to take over the project.
-
-This repository is no longer maintained!

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# PNP4Nagios
+
+## Performance Data Analyzer
+
+PNP4Nagios is an addon to Nagios Core which analyzes performance data provided by
+plugins and stores them automatically into RRD-databases.
+
+#### Version 0.7.0
+- Removed `MB_OVERLOAD_STRING` and `magic_quotes` checks for PHP8+ compability.
+
+
+Original [PNP4NAGIOS](https://github.com/pnp4nagios) repository is inactive and informs:
+
+> This project is no longer active.
+> 
+> Thank you for the many years we have worked together on this project.
+> 
+> Feel free to take over the project.
+> 
+> This repository is no longer maintained!

--- a/lib/kohana/system/core/utf8.php
+++ b/lib/kohana/system/core/utf8.php
@@ -49,17 +49,6 @@ if ( ! extension_loaded('iconv'))
 	);
 }
 
-if (extension_loaded('mbstring') AND (ini_get('mbstring.func_overload') & MB_OVERLOAD_STRING))
-{
-	trigger_error
-	(
-		'The <a href="http://php.net/mbstring">mbstring</a> extension is overloading PHP\'s native string functions. '.
-		'Disable this by setting mbstring.func_overload to 0, 1, 4 or 5 in php.ini or a .htaccess file.'.
-		'This application cannot be run without UTF-8 support.',
-		E_USER_ERROR
-	);
-}
-
 // Check PCRE support for Unicode properties such as \p and \X.
 $ER = error_reporting(0);
 define('PCRE_UNICODE_PROPERTIES', (bool) preg_match('/^\pL$/u', 'ñ'));

--- a/lib/kohana/system/libraries/Input.php
+++ b/lib/kohana/system/libraries/Input.php
@@ -14,9 +14,6 @@ class Input_Core {
 	// Enable or disable automatic XSS cleaning
 	protected $use_xss_clean = FALSE;
 
-	// Are magic quotes enabled?
-	protected $magic_quotes_gpc = FALSE;
-
 	// IP address of current user
 	public $ip_address;
 
@@ -42,7 +39,7 @@ class Input_Core {
 
 	/**
 	 * Sanitizes global GET, POST and COOKIE data. Also takes care of
-	 * magic_quotes and register_globals, if they have been enabled.
+	 * register_globals, if they have been enabled.
 	 *
 	 * @return  void
 	 */
@@ -53,20 +50,6 @@ class Input_Core {
 
 		if (Input::$instance === NULL)
 		{
-			// magic_quotes_runtime is enabled
-			if (function_exists('get_magic_quotes_runtime'))
-			{
-				ini_set('magic_quotes_runtime', 0);
-				Kohana::log('debug', 'Disable magic_quotes_runtime! It is evil and deprecated: http://php.net/magic_quotes');
-			}
-
-			// magic_quotes_gpc is enabled
-			if (function_exists('get_magic_quotes_gpc'))
-			{
-				$this->magic_quotes_gpc = TRUE;
-				Kohana::log('debug', 'Disable magic_quotes_gpc! It is evil and deprecated: http://php.net/magic_quotes');
-			}
-
 			// register_globals is enabled
 			if (ini_get('register_globals'))
 			{
@@ -427,12 +410,6 @@ class Input_Core {
 				$new_array[$this->clean_input_keys($key)] = $this->clean_input_data($val);
 			}
 			return $new_array;
-		}
-
-		if ($this->magic_quotes_gpc === TRUE)
-		{
-			// Remove annoying magic quotes
-			$str = stripslashes($str);
 		}
 
 		if ($this->use_xss_clean === TRUE)

--- a/share/pnp/application/vendor/fpdf/fpdf.php
+++ b/share/pnp/application/vendor/fpdf/fpdf.php
@@ -1039,9 +1039,6 @@ protected function _dochecks()
 	// Check mbstring overloading
 	if(ini_get('mbstring.func_overload') & 2)
 		$this->Error('mbstring overloading must be disabled');
-	// Ensure runtime magic quotes are disabled
-	if(get_magic_quotes_runtime())
-		@set_magic_quotes_runtime(0);
 }
 
 protected function _checkoutput()

--- a/share/pnp/application/vendor/fpdf/makefont/makefont.php
+++ b/share/pnp/application/vendor/fpdf/makefont/makefont.php
@@ -384,8 +384,6 @@ function MakeDefinitionFile($file, $type, $enc, $embed, $subset, $map, $info)
 function MakeFont($fontfile, $enc='cp1252', $embed=true, $subset=true)
 {
 	// Generate a font definition file
-	if(get_magic_quotes_runtime())
-		@set_magic_quotes_runtime(false);
 	ini_set('auto_detect_line_endings', '1');
 
 	if(!file_exists($fontfile))

--- a/share/pnp/install.php.in
+++ b/share/pnp/install.php.in
@@ -104,12 +104,6 @@ body { width: 42em; margin: 0 auto; font-family: sans-serif; font-size: 90%; }
 <td class="fail"><a href="http://docs.pnp4nagios.org/faq/i10">PHP JSON extension</a> not available</td>
 <?php endif ?>
 </tr>
-<th>PHP magic_quotes_gpc</th>
-<?php if (get_magic_quotes_gpc() == FALSE): ?>
-<td class="pass">Off</td>
-<?php else: $failed++ ?>
-<td class="fail">PHP <a href="http://docs.pnp4nagios.org/faq/i7">magic_quotes_gpc</a> is deprecated</td>
-<?php endif ?></tr>
 <?php if(function_exists('apache_get_modules')) : ?>
 <th>PHP socket extension</th>
 <?php if (function_exists('socket_create')): ?>
@@ -175,16 +169,6 @@ body { width: 42em; margin: 0 auto; font-family: sans-serif; font-size: 90%; }
 <td class="pass">Pass</td>
 <?php else: $failed++ ?>
 <td class="fail">The <a href="http://docs.pnp4nagios.org/faq/i5">iconv</a> extension is not loaded.</td>
-<?php endif ?>
-<tr>
-<?php if (extension_loaded('mbstring')): ?>
-<th>Mbstring Not Overloaded</th>
-<?php if (ini_get('mbstring.func_overload') & MB_OVERLOAD_STRING): $failed++ ?>
-<td class="fail">The <a href="http://docs.pnp4nagios.org/faq/i6">mbstring</a> extension is overloading PHP's native string functions.</td>
-<?php else: ?>
-<td class="pass">Pass</td>
-<?php endif ?>
-</tr>
 <?php endif ?>
 </tr>
 <tr>


### PR DESCRIPTION
0.7.0 - add php8 compat by removing `magic_quotes` & `MB_OVERLOAD_STRING` references and checks.