### PR TITLE
Fixes for CVE-2023-38349 and CVE-2023-38350

### DIFF
--- a/lib/kohana/system/core/Bootstrap.php
+++ b/lib/kohana/system/core/Bootstrap.php
@@ -31,6 +31,7 @@ Benchmark::start(SYSTEM_BENCHMARK.'_kohana_loading');
 // Load core files
 require SYSPATH.'core/utf8'.EXT;
 require SYSPATH.'core/Event'.EXT;
+require SYSPATH.'core/Security'.EXT;
 require SYSPATH.'core/Kohana'.EXT;
 
 // Prepare the environment

--- a/lib/kohana/system/core/Security.php
+++ b/lib/kohana/system/core/Security.php
@@ -1,0 +1,138 @@
+<?php defined('SYSPATH') OR die('No direct script access.');
+/**
+ * Security helper class.
+ *
+ * @package    Kohana
+ * @category   Security
+ * @author     Kohana Team
+ * @copyright  (c) 2007-2012 Kohana Team
+ * @license    http://kohanaframework.org/license
+ */
+class Security {
+
+	/**
+	 * @var  string  key name used for token storage
+	 */
+	public static $token_name = 'security_token';
+
+	/**
+	 * Generate and store a unique token which can be used to help prevent
+	 * [CSRF](http://wikipedia.org/wiki/Cross_Site_Request_Forgery) attacks.
+	 *
+	 *     $token = Security::token();
+	 *
+	 * You can insert this token into your forms as a hidden field:
+	 *
+	 *     echo Form::hidden('csrf', Security::token());
+	 *
+	 * And then check it when using [Validation]:
+	 *
+	 *     $array->rules('csrf', array(
+	 *         array('not_empty'),
+	 *         array('Security::check'),
+	 *     ));
+	 *
+	 * This provides a basic, but effective, method of preventing CSRF attacks.
+	 *
+	 * @param   boolean $new    force a new token to be generated?
+	 * @return  string
+	 * @uses    Session::instance
+	 */
+	public static function token($new = FALSE)
+	{
+		$session = Session::instance();
+
+		// Get the current token
+		$token = $session->get(Security::$token_name);
+
+		if ($new === TRUE OR ! $token)
+		{
+			// Generate a new unique token
+			if (function_exists('openssl_random_pseudo_bytes'))
+			{
+				// Generate a random pseudo bytes token if openssl_random_pseudo_bytes is available
+				// This is more secure than uniqid, because uniqid relies on microtime, which is predictable
+				$token = base64_encode(openssl_random_pseudo_bytes(32));
+			}
+			else
+			{
+				// Otherwise, fall back to a hashed uniqid
+				$token = sha1(uniqid(NULL, TRUE));
+			}
+
+			// Store the new token
+			$session->set(Security::$token_name, $token);
+		}
+
+		return $token;
+	}
+
+	/**
+	 * Check that the given token matches the currently stored security token.
+	 *
+	 *     if (Security::check($token))
+	 *     {
+	 *         // Pass
+	 *     }
+	 *
+	 * @param   string  $token  token to check
+	 * @return  boolean
+	 * @uses    Security::token
+	 */
+	public static function check($token)
+	{
+		return Security::slow_equals(Security::token(), $token);
+	}
+	
+	
+	
+	/**
+	 * Compare two hashes in a time-invariant manner.
+	 * Prevents cryptographic side-channel attacks (timing attacks, specifically)
+	 * 
+	 * @param string $a cryptographic hash
+	 * @param string $b cryptographic hash
+	 * @return boolean
+	 */
+	public static function slow_equals($a, $b) 
+	{
+		$diff = strlen($a) ^ strlen($b);
+		for($i = 0; $i < strlen($a) AND $i < strlen($b); $i++)
+		{
+			$diff |= ord($a[$i]) ^ ord($b[$i]);
+		}
+		return $diff === 0; 
+	}
+
+
+	/**
+	 * Deprecated for security reasons.
+	 * See https://github.com/kohana/kohana/issues/107
+	 *
+	 * Remove image tags from a string.
+	 *
+	 *     $str = Security::strip_image_tags($str);
+	 *
+	 * @deprecated since version 3.3.6
+	 * @param   string  $str    string to sanitize
+	 * @return  string
+	 */
+	public static function strip_image_tags($str)
+	{
+		return preg_replace('#<img\s.*?(?:src\s*=\s*["\']?([^"\'<>\s]*)["\']?[^>]*)?>#is', '$1', $str);
+	}
+
+	/**
+	 * Encodes PHP tags in a string.
+	 *
+	 *     $str = Security::encode_php_tags($str);
+	 *
+	 * @param   string  $str    string to sanitize
+	 * @return  string
+	 */
+	public static function encode_php_tags($str)
+	{
+		return str_replace(array('<?', '?>'), array('&lt;?', '?&gt;'), $str);
+	}
+
+}

--- a/share/pnp/application/controllers/ajax.php
+++ b/share/pnp/application/controllers/ajax.php
@@ -15,7 +15,7 @@ class Ajax_Controller extends System_Controller  {
     }
 
     public function index(){
-        url::redirect("start", 302); 
+        url::redirect("start", 302);
     }
 
     public function search() {
@@ -39,7 +39,7 @@ class Ajax_Controller extends System_Controller  {
             $this->session->set('timerange-reset', 1);
         }
     }
-	
+
 	public function filter($what){
         $received_token = $_POST['csrf_token'];
         $token = Security::token();
@@ -50,11 +50,11 @@ class Ajax_Controller extends System_Controller  {
         }
 
         if($what == 'set-sfilter'){
-            $this->session->set('sfilter', $_POST['sfilter']);
+            $this->session->set('sfilter', htmlspecialchars($_POST['sfilter']));
         }elseif($what == 'set-spfilter'){
-			$this->session->set('spfilter', $_POST['spfilter']);
-		}elseif($what == 'set-pfilter'){
-            $this->session->set('pfilter', $_POST['pfilter']);
+          $this->session->set('spfilter', htmlspecialchars($_POST['spfilter']));
+        }elseif($what == 'set-pfilter'){
+          $this->session->set('pfilter', htmlspecialchars($_POST['pfilter']));
         }
     }
 
@@ -88,7 +88,7 @@ class Ajax_Controller extends System_Controller  {
                 return false;
             }
 
-            $item = $_POST['item'];
+            $item = htmlspecialchars($_POST['item']);
             $basket = $this->session->get("basket");
             if(!is_array($basket)){
                 $basket = [];
@@ -118,7 +118,7 @@ class Ajax_Controller extends System_Controller  {
                 return false;
             }
 
-            $items = $_POST['items'];
+            $item = htmlspecialchars($_POST['item']);
             $basket = explode(',', $items);
             array_pop($basket);
             $this->session->set("basket", $basket);
@@ -142,7 +142,7 @@ class Ajax_Controller extends System_Controller  {
             }
 
             $basket = $this->session->get("basket");
-            $item_to_remove = $_POST['item'];
+            $item_to_remove = htmlspecialchars($_POST['item']);
             $new_basket = array();
             foreach($basket as $item){
                 if($item ==  $item_to_remove){

--- a/share/pnp/application/controllers/ajax.php
+++ b/share/pnp/application/controllers/ajax.php
@@ -41,6 +41,14 @@ class Ajax_Controller extends System_Controller  {
     }
 	
 	public function filter($what){
+        $received_token = $_POST['csrf_token'];
+        $token = Security::token();
+
+        if (!Security::check($received_token, $token)){
+            echo "CSRF Token invalid";
+            return false;
+        }
+
         if($what == 'set-sfilter'){
             $this->session->set('sfilter', $_POST['sfilter']);
         }elseif($what == 'set-spfilter'){
@@ -72,6 +80,14 @@ class Ajax_Controller extends System_Controller  {
                 }
             }
         }elseif($action == "add"){
+            $received_token = $_POST['csrf_token'];
+            $token = Security::token();
+
+            if (!Security::check($received_token, $token)){
+                echo "CSRF Token invalid";
+                return false;
+            }
+
             $item = $_POST['item'];
             $basket = $this->session->get("basket");
             if(!is_array($basket)){
@@ -94,6 +110,14 @@ class Ajax_Controller extends System_Controller  {
                       );
             }
         }elseif($action == "sort"){
+            $received_token = $_POST['csrf_token'];
+            $token = Security::token();
+
+            if (!Security::check($received_token, $token)){
+                echo "CSRF Token invalid";
+                return false;
+            }
+
             $items = $_POST['items'];
             $basket = explode(',', $items);
             array_pop($basket);
@@ -109,6 +133,14 @@ class Ajax_Controller extends System_Controller  {
                       );
             }
         }elseif($action == "remove"){
+            $received_token = $_POST['csrf_token'];
+            $token = Security::token();
+
+            if (!Security::check($received_token, $token)){
+                echo "CSRF Token invalid";
+                return false;
+            }
+
             $basket = $this->session->get("basket");
             $item_to_remove = $_POST['item'];
             $new_basket = array();

--- a/share/pnp/application/controllers/system.php
+++ b/share/pnp/application/controllers/system.php
@@ -54,6 +54,9 @@ class System_Controller extends Template_Controller {
 	if(! in_array(Router::$controller, array("image", "image_special", "xport"))){
             $this->session = Session::instance();
 
+            # Initialize CSRF Token
+            $this->session->set("csrf_token", Security::token());
+
             # Session withou theme info
             if($this->session->get("theme","new") == "new"){
                 if($this->theme){

--- a/share/pnp/application/views/template.php
+++ b/share/pnp/application/views/template.php
@@ -44,16 +44,16 @@ jQuery(window).load(
 	if( delta < 600 )
 	    delta = 600;
 	var sec_per_px = parseInt( delta / graph_width);
-	var start = ostart + Math.ceil( selection.x1 * sec_per_px );  
-	var end   = ostart + ( selection.x2 * sec_per_px );  
-        window.location = link + '&start=' + start + '&end=' + end ; 
+	var start = ostart + Math.ceil( selection.x1 * sec_per_px );
+	var end   = ostart + ( selection.x2 * sec_per_px );
+        window.location = link + '&start=' + start + '&end=' + end ;
 
     }
-	
+
 	var sfilter = "<?php echo $this->session->get('sfilter') ?>";
 	var spfilter = "<?php echo $this->session->get('spfilter') ?>";
 	var pfilter = "<?php echo $this->session->get('pfilter') ?>";
-	
+
 	if(jQuery("#service-filter").length) {
 		console.log("send keyup")
 		jQuery("#service-filter").keyup()
@@ -76,7 +76,7 @@ jQuery(document).ready(function(){
             data: { item: item },
             success: function(msg){
                 jQuery("#basket_items").html(msg);
-                window.location.reload() 
+                window.location.reload()
             }
         });
     });
@@ -85,12 +85,12 @@ jQuery(document).ready(function(){
             type: "POST",
             url: path + "ajax/basket/clear",
             success: function(msg){
-                window.location.reload() 
+                window.location.reload()
             }
         });
     });
     jQuery("#basket-show").live("click", function(){
-                window.location.href = path + 'page/basket' 
+                window.location.href = path + 'page/basket'
     });
     jQuery(".basket_action_remove a").live("click", function(){
         var item = (this.id)
@@ -100,7 +100,7 @@ jQuery(document).ready(function(){
             data: { item: item },
             success: function(msg){
                 jQuery("#basket_items").html(msg);
-                window.location.reload() 
+                window.location.reload()
             }
         });
     });
@@ -112,7 +112,7 @@ jQuery(document).ready(function(){
                 url: path + "ajax/basket/sort",
                 data: { items: items },
                 success: function(msg){
-                    window.location.reload() 
+                    window.location.reload()
                 }
             });
         }

--- a/share/pnp/application/views/template.php
+++ b/share/pnp/application/views/template.php
@@ -70,10 +70,11 @@ jQuery(document).ready(function(){
     jQuery("img").fadeIn(1500);
     jQuery("#basket_action_add a").live("click", function(){
         var item = (this.id)
+		var token = "<?php echo $this->session->get('csrf_token') ?>"
         jQuery.ajax({
             type: "POST",
             url: path + "ajax/basket/add",
-            data: { item: item },
+            data: { item: item, "csrf_token": token },
             success: function(msg){
                 jQuery("#basket_items").html(msg);
                 window.location.reload()
@@ -94,10 +95,11 @@ jQuery(document).ready(function(){
     });
     jQuery(".basket_action_remove a").live("click", function(){
         var item = (this.id)
+		var token = "<?php echo $this->session->get('csrf_token') ?>"
         jQuery.ajax({
             type: "POST",
             url: path + "ajax/basket/remove/",
-            data: { item: item },
+            data: { item: item, "csrf_token": token },
             success: function(msg){
                 jQuery("#basket_items").html(msg);
                 window.location.reload()
@@ -106,11 +108,12 @@ jQuery(document).ready(function(){
     });
     jQuery("#basket_items" ).sortable({
         update: function(event, ui) {
+		var token = "<?php echo $this->session->get('csrf_token') ?>"
 	    var items = jQuery(this).sortable('toArray').toString();
             jQuery.ajax({
                 type: "POST",
                 url: path + "ajax/basket/sort",
-                data: { items: items },
+                data: { items: items, "csrf_token": token },
                 success: function(msg){
                     window.location.reload()
                 }
@@ -135,10 +138,11 @@ jQuery(document).ready(function(){
 		}else{
 			jQuery("#service-filter").css('background-color','white');
 		}
+		var token = "<?php echo $this->session->get('csrf_token') ?>"
 		jQuery.ajax({
 			type: "POST",
 			url: path + "ajax/filter/set-sfilter",
-			data: { sfilter: sfilter }
+            data: { sfilter: sfilter, "csrf_token": token }
 		});
         jQuery("#services span[id^='service']").each(function () {
             if (jQuery(this).attr('id').search(new RegExp("service-.*" + sfilter,"i")) == 0) {
@@ -156,10 +160,11 @@ jQuery(document).ready(function(){
 		}else{
 			jQuery("#special-filter").css('background-color','white');
 		}
+		var token = "<?php echo $this->session->get('csrf_token') ?>"
 		jQuery.ajax({
 			type: "POST",
 			url: path + "ajax/filter/set-spfilter",
-			data: { spfilter: spfilter }
+            data: { spfilter: spfilter, "csrf_token": token }
 		});
         jQuery("#special-templates span[id^='special']").each(function () {
             if (jQuery(this).attr('id').search(new RegExp("special-.*" + spfilter,"i")) == 0) {
@@ -177,10 +182,11 @@ jQuery(document).ready(function(){
 		}else{
 			jQuery("#page-filter").css('background-color','white');
 		}
+		var token = "<?php echo $this->session->get('csrf_token') ?>"
 		jQuery.ajax({
 			type: "POST",
 			url: path + "ajax/filter/set-pfilter",
-			data: { pfilter: pfilter }
+            data: { pfilter: pfilter, "csrf_token": token }
 		});
         jQuery("#pages span[id^='page']").each(function () {
             if (jQuery(this).attr('id').search(new RegExp("page-.*" + pfilter,"i")) == 0) {


### PR DESCRIPTION
Combined the following PRs from the old Repo into this one.

Details:
- https://github.com/pnp4nagios/pnp4nagios.ToBeDeleted/pull/16
- https://github.com/pnp4nagios/pnp4nagios.ToBeDeleted/pull/17

##  This PR adresses https://github.com/advisories/GHSA-99c6-mjfj-w86j

the AJAX controller allows for stored cross site scripting due to missing input validation.

Before this fix you could send and store arbitrary characters via the basket API and filters

Examples:
   - `item="><svg/onclick=alert('foobar')>` in add/basket
   - `sfilters="><svg/onclick=alert('foobar')>`

```bash
curl 'http://localhost:8080/pnp4nagios//ajax/basket/add' --compressed -X POST 
-H 'Accept: */*' -H 'Accept-Language: en-US,en;q=0.5' 
-H 'Accept-Encoding: gzip, deflate, br' 
-H 'Referer: http://localhost:8080/pnp4nagios/graph?host=.pnp-internal&srv=runtime' 
-H 'Origin: http://localhost:8080' 
-H 'Connection: keep-alive' 
-H 'Sec-Fetch-Site: same-origin' 
-H 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8' 
-H 'X-Requested-With: XMLHttpRequest'
-H 'Pragma: no-cache' 
-H 'Cache-Control: no-cache' --data-raw $'item="><svg/onclick=alert(\'foobar\')>'
```

![251481188-2782420f-397b-4f57-8929-f50b94bcbe14](https://github.com/pnp4nagios/pnp4nagios/assets/7090372/f989e7ad-8bb1-47e6-acc3-10a968bff55e)

## This PR adresses https://github.com/advisories/GHSA-jqw4-fm67-g67w

The controller was missing CSRF protection. This fix uses per-session tokens that are send with each POST request to the controller.

For this, I backported the Security.php from a newer Kohana, since an update of the entire Framework seemed counterproductive for this particular fix.

I'm not super fluent in PHP and therefore decided on a guard clause pattern, hope that's OK. Let me know if I should adjust anything.