### PR TITLE
install.php: add check for SimpleXML extension presence

### DIFF
--- a/share/pnp/install.php.in
+++ b/share/pnp/install.php.in
@@ -81,6 +81,14 @@ body { width: 42em; margin: 0 auto; font-family: sans-serif; font-size: 90%; }
 <?php endif ?>
 </tr>
 <tr>
+<th>PHP XML extension</th>
+<?php if (function_exists('simplexml_load_file')): ?>
+<td class="pass">Pass</td>
+<?php else: $failed++ ?>
+<td class="fail">PHP SimpleXML extension not available</td>
+<?php endif ?>
+</tr>
+<tr>
 <th>PHP zlib extension</th>
 <?php if (function_exists('gzfile')): ?>
 <td class="pass">Pass</td>


### PR DESCRIPTION
Debian 12 has a separate package for the XML/SimpleXML extension, hence this helpful check.