### PR TITLE
Fix for 8.4 E_Strict deprecation

### DIFF
--- a/lib/kohana/system/core/Kohana.php
+++ b/lib/kohana/system/core/Kohana.php
@@ -129,7 +129,12 @@ final class Kohana
         }
 
         // Disable notices and "strict" errors
-        $ER = error_reporting(~E_NOTICE & ~E_STRICT);
+        if(PHP_VERSION_ID >= 70400) {
+            $ER = error_reporting(~E_NOTICE);
+        }
+        else {
+            $ER = error_reporting(~E_NOTICE & ~E_STRICT);
+        }
 
         // Set the user agent
         self::$user_agent = ( ! empty($_SERVER['HTTP_USER_AGENT']) ? trim($_SERVER['HTTP_USER_AGENT']) : '');


### PR DESCRIPTION
Fix for https://github.com/pnp4nagios/pnp4nagios/issues/77 
Works for me, tested on 8.4.7
based on https://php.watch/versions/8.4/E_STRICT-deprecated
Should be backwards compatible to at least 7.x


