### PR TITLE
Script process_perfdata.pl has a bug in the GetLock implementation

### DIFF
--- a/scripts/process_perfdata.pl.in
+++ b/scripts/process_perfdata.pl.in
@@ -1705,6 +1705,7 @@ sub GetLock
     my $FH;
     my $madewhen;
     while ($tries > 0) {
+        $tries--;
         if (sysopen($FH,$dlockfile,O_WRONLY|O_CREAT|O_EXCL)) {
             my $t = time();
             print $FH "$t\n";
@@ -1715,11 +1716,16 @@ sub GetLock
         if (open($FH,"<$dlockfile")) {
 	    while (<$FH>) {
 		chomp;
-		next if /^\s*$/;
-		$madewhen = $_ unless defined $madewhen;
+		next unless /^(\d+)$/;
+		$madewhen = $1;
+		last;
             }
 	    close($FH);
-	    next unless defined $madewhen; 
+
+	    # Use the last modified time of the lock file if no time is found
+	    $madewhen ||= (stat($dlockfile))[9];
+
+	    next unless defined $madewhen;
             my $dt = time() - $madewhen;
             if ($dt > $conf{MAXLOCK}) {
                 print_log("DEBUG: old lock file $lockfile deleted",3);
@@ -1727,7 +1733,6 @@ sub GetLock
                 next;
             }
         }
-        $tries--;
         print_log("DEBUG: PID $$ did not get lock on $lockfile, $tries remain",3);
         usleep($wait);
     }

--- a/scripts/process_perfdata.pl.in
+++ b/scripts/process_perfdata.pl.in
@@ -355,7 +355,7 @@ sub process_perfdata_file {
     }
 
     GetLock('file1.lock',10,0.2);
-    
+
     # empty file?
     my $n = (stat($opt_b))[7];
     if (!defined($n) || $n == 0) {
@@ -386,7 +386,7 @@ sub process_perfdata_file {
 	}
 	close($tmpfh);
     }
-    
+
     print_log( "reading $pdfile for bulk update", 2 );
     open( PDFILE, "< $pdfile" );
     my $count = 0;
@@ -412,7 +412,7 @@ sub process_perfdata_file {
     }else {
         print_log( "Could not delete $pdfile:$!", 1 );
     }
-    return $count; 
+    return $count;
 }
 
 #
@@ -1348,7 +1348,7 @@ sub handle_signal {
                 if ( -f $pdfile) {
                     if ( unlink("$pdfile") == 1 ) {
                         print_log( "*** TIMEOUT: $pdfile deleted", 0 );
-                    }                    
+                    }
                     else {
                         print_log( "*** TIMEOUT: Could not delete $pdfile:$!", 0 );
                     }
@@ -1408,7 +1408,7 @@ sub check_internals {
     if (!GetLock('stats',20,0.25)) {
         print_log("ERROR: failed to get stats file lock, bailing",0);
         return;
-    }    
+    }
 
     opendir(STATS, $conf{'STATS_DIR'});
     while ( defined ( my $file = readdir STATS) ){
@@ -1440,7 +1440,7 @@ sub read_internals {
         }
         push(@nfiles,$newfile);
     }
-    ReleaseLock('stats'); 
+    ReleaseLock('stats');
 
     foreach my $newfile (@nfiles) {
         print_log("DEBUG: processing stats file $newfile",3);
@@ -1701,7 +1701,7 @@ sub GetLock
     my $wait = shift;
     $wait = $wait * 1000000 if defined($wait) && $wait < 10;
     $wait = 1000000 unless defined $wait;
-    
+
     my $FH;
     my $madewhen;
     while ($tries > 0) {
@@ -1740,7 +1740,7 @@ sub ReleaseLock
     my $lockfile = shift;
     $lockfile = 'ppd.lock' unless defined $lockfile;
     my $dlockfile = $conf{LOCKDIR}.$lockfile;
-    
+
     my $iss = unlink $dlockfile;
     print_log("DEBUG: PID $$ release lock on $lockfile, OK=$iss",3);
 }


### PR DESCRIPTION
**Describe the bug**

In `process_perfdata.pl`, the `GetLock` function attempts to write the epoch time to the lockfile. If this fails then it will try to read the epoch time from the existing lockfile. If nothing can be read from the lockfile it loops, tries again but never decrements the `$tries` counter so it goes into an infinite loop. After a while it times out and is killed by the ALARM signal then the script crashes out without any useful error message.

**To Reproduce**

I haven't tried that hard to reproduce the problem and I'm not entirely sure what state the lock file got into that `process_perfdata.pl` couldn't deal with it. The bug in the code is fairly obvious though and a stuck lock file on my system caused `process_perfdata.pl` to fail until I manually removed the lockfile. 

**Expected behavior**

That process_perfdata.pl would give up after `$tries` attempts and delete `$lockfile` when it is more than `MAXLOCK` seconds old.

**Server**
 - NagiosCore : `naemon-core-1.4.4-21.28.x86_64`
 - OS: AlmaLinux 9.6
